### PR TITLE
fix(Plugins): Do not export files which don't follow MiAZ format filenames

### DIFF
--- a/MiAZ/backend/util.py
+++ b/MiAZ/backend/util.py
@@ -225,7 +225,7 @@ class MiAZUtil(GObject.GObject):
                 try:
                     # preserve metadata
                     shutil.copy2(source, target)
-                    self.log.info("{source} copied to {target}")
+                    self.log.info(f"{source} copied to {target}")
                 except Exception as error:
                     self.log.error(error)
             else:

--- a/data/resources/plugins/export2dir.py
+++ b/data/resources/plugins/export2dir.py
@@ -91,13 +91,17 @@ class Export2Dir(GObject.GObject, Peas.Activatable):
                         for item in items:
                             thispath = []
                             thispath.append(dirpath)
-                            paths = get_pattern_paths(item)
-                            for key in keys:
-                                thispath.append(paths[key])
-                            target = os.path.join(*thispath)
-                            os.makedirs(target, exist_ok=True)
-                            source = os.path.join(repository.docs, item.id)
-                            util.filename_export(source, target)
+                            try:
+                                paths = get_pattern_paths(item)
+                                for key in keys:
+                                    thispath.append(paths[key])
+                                target = os.path.join(*thispath)
+                                os.makedirs(target, exist_ok=True)
+                                source = os.path.join(repository.docs, item.id)
+                                util.filename_export(source, target)
+                            except ValueError as error:
+                                self.log.error(f"{os.path.basename(source)} couldn't be exported.")
+                                self.log.error("Reason: filename not compliant with MiAZ format")
                     else:
                         for item in items:
                             source = os.path.join(repository.docs, item.id)


### PR DESCRIPTION
Fix export2dir plugin.
Filenames not following the MiAZ pattern returned error during the export.