### PR TITLE
0.0.44

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,17 @@ install:
 	sudo meson setup builddir_system --prefix=/usr --wipe
 	sudo ninja -C builddir_system install
 
+install_msys2:
+	rm -rf builddir_system
+	meson builddir_system --prefix=/usr
+	meson setup builddir_system --prefix=/usr --wipe
+	ninja -C builddir_system install
+
 uninstall:
 	cd builddir_system && sudo ninja uninstall
+
+uninstall_msys2:
+	cd builddir_system && ninja uninstall
 
 user:
 	rm -rf builddir_user

--- a/MiAZ/frontend/desktop/widgets/workspace.py
+++ b/MiAZ/frontend/desktop/widgets/workspace.py
@@ -316,6 +316,7 @@ class MiAZWorkspace(Gtk.Box):
         button.set_has_frame(True)
         self.app.add_widget('workspace-togglebutton-pending-docs', button)
         button.set_visible(False)
+        button.set_active(False)
         hbox.append(button)
 
         headerbar = self.app.get_widget('headerbar')
@@ -595,7 +596,10 @@ class MiAZWorkspace(Gtk.Box):
 
         togglebutton = self.app.get_widget('workspace-togglebutton-pending-docs')
         togglebutton.set_visible(show_pending)
-        togglebutton.set_active(show_pending)
+
+        # FIXME: DEACTIVATE SHOW_PENDING DOCUMENTS. REVIEW WORKFLOW LOGIC
+        show_pending = False
+        togglebutton.set_active(False)
         self.review = show_pending
 
         return False

--- a/MiAZ/frontend/desktop/widgets/workspace.py
+++ b/MiAZ/frontend/desktop/widgets/workspace.py
@@ -551,7 +551,7 @@ class MiAZWorkspace(Gtk.Box):
                                         active=active
                                     )
                             )
-            except (IndexError, KeyError) as error:
+            except (IndexError, KeyError):
                 items.append(MiAZItem
                                     (
                                         id=os.path.basename(filename),

--- a/MiAZ/miaz.py
+++ b/MiAZ/miaz.py
@@ -57,10 +57,10 @@ ENV['APP']['contributors'] = []
 ENV['APP']['website'] = 'https://github.com/t00m/MiAZ'
 
 # Process
-PID = os.getpid()
-ENV['PS'] = {}
-ENV['PS']['PID'] = PID
-ENV['PS']['NAME'] = open('/proc/%d/comm' % PID, 'r').read().strip()
+# ~ PID = os.getpid()
+# ~ ENV['PS'] = {}
+# ~ ENV['PS']['PID'] = PID
+# ~ ENV['PS']['NAME'] = open('/proc/%d/comm' % PID, 'r').read().strip()
 
 # Configuration
 ENV['CONF'] = {}

--- a/data/resources/plugins/scan.py
+++ b/data/resources/plugins/scan.py
@@ -30,17 +30,21 @@ class MiAZImportFromScanPlugin(GObject.GObject, Peas.Activatable):
 
     def _search_scan_app(self):
         scanapp = None
-        desktop_files = glob.glob('/usr/share/applications/*.desktop')
-        DAI = Gio.DesktopAppInfo()
-        for desktop_path in desktop_files:
-            desktop_name = os.path.basename(desktop_path)
-            try:
-                appinfo = DAI.new(desktop_name)
-                if re.search('scan', appinfo.get_categories(), re.IGNORECASE):
-                    scanapp = appinfo
-                    break
-            except TypeError:
-                pass
+        try:
+            desktop_files = glob.glob('/usr/share/applications/*.desktop')
+            DAI = Gio.DesktopAppInfo()
+            for desktop_path in desktop_files:
+                desktop_name = os.path.basename(desktop_path)
+                try:
+                    appinfo = DAI.new(desktop_name)
+                    if re.search('scan', appinfo.get_categories(), re.IGNORECASE):
+                        scanapp = appinfo
+                        break
+                except TypeError:
+                    self.log.error(f"Plugin 'scan' couldn't be activated")
+        except AttributeError:
+            # Not available in Windows/MSYS2
+            self.log.error(f"Plugin 'scan' couldn't be activated")
         return scanapp
 
     def do_activate(self):

--- a/data/resources/plugins/scan.py
+++ b/data/resources/plugins/scan.py
@@ -41,10 +41,10 @@ class MiAZImportFromScanPlugin(GObject.GObject, Peas.Activatable):
                         scanapp = appinfo
                         break
                 except TypeError:
-                    self.log.error(f"Plugin 'scan' couldn't be activated")
+                    self.log.error("Plugin 'scan' couldn't be activated")
         except AttributeError:
             # Not available in Windows/MSYS2
-            self.log.error(f"Plugin 'scan' couldn't be activated")
+            self.log.error("Plugin 'scan' couldn't be activated")
         return scanapp
 
     def do_activate(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 PyGObject==3.42.2
-rich==13.7.1
 setuptools==66.1.1

--- a/scripts/setup_msys2_env.sh
+++ b/scripts/setup_msys2_env.sh
@@ -1,0 +1,1 @@
+pacman -S mingw-w64-x86_64-jq

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 # ~ VERSION = o.decode('utf-8').strip().replace('"', '')
 VERSION = '0.0.44'
 
-with open('README.md', 'r') as f:
+with open('README.md') as f:
     LONG_DESCRIPTION = f.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,12 @@ import glob
 import subprocess
 from setuptools import setup
 
-cmd_version = 'meson introspect meson.build --projectinfo | jq .version'
-o, e = subprocess.Popen([cmd_version], shell=True, stdout=subprocess.PIPE).communicate()
-VERSION = o.decode('utf-8').strip().replace('"', '')
+# ~ cmd_version = 'meson introspect meson.build --projectinfo | jq .version'
+# ~ o, e = subprocess.Popen([cmd_version], shell=True, stdout=subprocess.PIPE).communicate()
+# ~ VERSION = o.decode('utf-8').strip().replace('"', '')
+VERSION = '0.0.44'
 
-with open('data/docs/README', 'r') as f:
+with open('README.md', 'r') as f:
     LONG_DESCRIPTION = f.read()
 
 

--- a/test_msys2.sh
+++ b/test_msys2.sh
@@ -1,0 +1,1 @@
+rm -f C:/msys64/usr/bin/miaz; make uninstall_msys2; make install_msys2


### PR DESCRIPTION
MiAZ can be executed on Windows now.
Display pending documents only on demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new commands to install and uninstall MSYS2 environment setup.
  - The setup script now installs `jq` using `pacman`.

- **Enhancements**
  - Updated workspace logic to improve button and pending document handling.
  - Improved error handling and logging in the `Scan` plugin.
  - Modified version determination method and README path in `setup.py`.

- **Removals**
  - Removed the `rich` package from `requirements.txt`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->