### PR TITLE
0.1.17

### DIFF
--- a/MiAZ/frontend/desktop/services/actions.py
+++ b/MiAZ/frontend/desktop/services/actions.py
@@ -245,12 +245,22 @@ class MiAZActions(GObject.GObject):
         self.emit('settings-loaded', dialog_app_settings)
 
     def show_repository_settings(self, *args):
-        window_main = self.app.get_widget('window')
-        window_repoconfig = MiAZRepoSettings(self.app)
-        window_repoconfig.set_transient_for(window_main)
-        window_repoconfig.set_modal(True)
-        window_repoconfig.update()
-        window_repoconfig.present()
+        try:
+            # Continue if a default repository exists
+            appconf = self.app.get_config('App')
+            repo_id = appconf.get('current').replace('_', ' ')
+            window_main = self.app.get_widget('window')
+            window_repoconfig = MiAZRepoSettings(self.app)
+            window_repoconfig.set_transient_for(window_main)
+            window_repoconfig.set_modal(True)
+            window_repoconfig.update()
+            window_repoconfig.present()
+        except AttributeError:
+            srvdlg = self.app.get_service('dialogs')
+            parent = self.app.get_widget('window')
+            title = "Repository management"
+            body = "There is no repositories configured.\nPlease, create one."
+            srvdlg.show_error(title=title, body=body, parent=parent)
 
     def show_app_about(self, *args):
         # FIXME: App icon not displayed in local installation

--- a/MiAZ/frontend/desktop/widgets/pluginuimanager.py
+++ b/MiAZ/frontend/desktop/widgets/pluginuimanager.py
@@ -99,7 +99,7 @@ class MiAZPluginUIManager(Gtk.Box):
         btnInfo = self.factory.create_button(icon_name='io.github.t00m.MiAZ-dialog-information-symbolic', callback=self._show_plugin_info, css_classes=[''])
         btnInfo.set_valign(Gtk.Align.CENTER)
         toolbar.append(btnInfo)
-        btnConfig = self.factory.create_button(icon_name='io.github.t00m.MiAZ-config-symbolic', callback=self._configure_plugin_options, css_classes=['suggested-action'])
+        btnConfig = self.factory.create_button(icon_name='io.github.t00m.MiAZ-config-symbolic', callback=self._configure_plugin_options, css_classes=[''])
         self.app.add_widget('plugin-view-system-button-config', btnConfig)
         btnConfig.set_valign(Gtk.Align.CENTER)
         toolbar.append(btnConfig)

--- a/MiAZ/frontend/desktop/widgets/sidebar.py
+++ b/MiAZ/frontend/desktop/widgets/sidebar.py
@@ -260,8 +260,9 @@ class MiAZSidebar(Adw.Bin):
         for ddId in dropdowns:
             dropdowns[ddId].set_selected(0)
         workspace_view = self.app.get_widget('workspace-view')
-        workspace_view.refilter()
-        self.log.debug("All filters cleared")
+        if workspace_view is not None:
+            workspace_view.refilter()
+            self.log.debug("All filters cleared")
 
     def set_title(self, title: str=''):
         sidebar_title = self.app.get_widget('sidebar-title')

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('MiAZ',
-          version : '0.1.16+build.200',
+          version : '0.1.16+build.213',
     meson_version: '>= 1.5.1',
   default_options: [ 'warning_level=2',
                    ],

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('MiAZ',
-          version : '0.1.16+build.213',
+          version : '0.1.17+build.13',
     meson_version: '>= 1.5.1',
   default_options: [ 'warning_level=2',
                    ],


### PR DESCRIPTION
🛠 Fixes
- do not allow clear filters if there is no workspace loaded
- update plugin available view correctly
- do not open repository preferences if no repository exists or there is no default repository
