### PR TITLE
0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,60 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+#### Plugins
+
+- **adddir**: Fixed `threading.Thread(target=self.import_directory(filepaths))` — function
+  was called immediately and its return value (`None`) passed as target; import ran on
+  the main GTK thread and the spawned thread was a no-op. Fixed to pass `target` and
+  `args` separately.
+- **adddir**: Fixed `TypeError` — `dialog.select_folder_finish()` returns `Gio.File`, not
+  a path string; `os.path.join(Gio.File, '*')` crashed immediately. Added `folder.get_path()`.
+- **adddir**: Fixed file I/O (`filename_import`) scheduled via `GLib.idle_add` from the
+  background thread, which queued it back onto the main GTK thread. I/O now runs directly
+  in the thread; only the progress callback uses `idle_add`.
+- **adddir**: Fixed watcher staying permanently disabled when an import was cancelled or
+  raised — `watcher.set_active(False)` had no corresponding re-activation on error paths.
+  Added `try/finally` to guarantee restoration.
+- **adddoc**: Fixed `show_error(body=error)` passing an `Exception` object to the dialog
+  instead of a string. Changed to `body=str(error)`.
+- **adddoc**: Fixed untranslatable `title='Import documents'` and `body=f'...'` strings;
+  both are now wrapped with `_()` using `.format()` for the dynamic value.
+- **massrename**: Fixed `dropdown.get_selected_item()` returning `None` when no item is
+  selected; `.id` access raised `AttributeError`, silently swallowed by a FIXME catch-all.
+  Added explicit `None` guard with `continue`.
+- **massrename**: Fixed `_(f'Rename {len(items)} ... <b>{i_title}</b> ...')` — an f-string
+  inside `_()` is invisible to xgettext. Changed to `_('...{count}...{field}...').format(...)`.
+- **renameitem**: Fixed `view.get_selection()` called in `do_activate()` before
+  `'workspace-loaded'` fires — if the workspace view is not yet registered, `view` is
+  `None` and the plugin fails to load. Moved the `selection.connect()` call into
+  `startup()` with a `None` guard.
+- **viewitem**: Fixed `view.cv.connect("activate", ...)` and `view.get_selection().connect()`
+  called in `do_activate()` before the workspace was loaded. Moved both into `startup()`
+  with `None` and `hasattr` guards.
+- **wstoggleview**: Fixed `NameError` at module load — `_()` was used in the `plugin_info`
+  dict before `_` was imported. Added `from gettext import gettext as _`.
+- **wstoggleview**: Fixed bare `except:` in `show_settings()` catching `SystemExit` and
+  `KeyboardInterrupt`. Changed to `except KeyError:`.
+- **wstoggleview**: Removed dead `check_plugin()` method that referenced `self.plugin_info`
+  (never assigned) — would `AttributeError` if called.
+- **wstoggleview**: Fixed `do_deactivate()` logging at `error` level for normal deactivation.
+  Changed to `self.log.debug(...)`.
+- **All 7 plugins**: Fixed `do_deactivate()` not implemented — disabling a plugin left
+  orphaned UI elements and duplicate signal handlers on re-enable; `plugin.started()` was
+  still `True` so re-activation did nothing. All plugins now call
+  `self.plugin.set_started(False)` in `do_deactivate()`.
+
+#### Low quality (plugins)
+
+- **adddir**: Fixed typo "Importing file file {i+1}/..." — "file" was doubled.
+- **massrename**: Added `Field[Concept] = 5` — the local `Field` dict was missing index 5,
+  inconsistent with the 7-field model and a latent `KeyError`.
+- **massrename**: Removed commented-out deprecated `get_style_context().add_class()` call.
+- **renameitem**: Removed dead comment referencing undefined `selected_item` and `i_title`.
+- **adddoc, massrename, viewitem**: Fixed `# File: export2csv.py` copy-paste artefact in
+  module docstrings.
+- **wstoggleview**: Fixed `# File: hello.py` copy-paste artefact in module docstring.
+
 #### Backend
 
 - **projects**: Fixed crash on startup — `conf['Project']` key does not exist in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,176 @@
+# Changelog
+
+All notable changes to MiAZ are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased] — 2026-04-25
+
+### Fixed
+
+#### Backend
+
+- **projects**: Fixed crash on startup — `conf['Project']` key does not exist in the
+  config dict; now uses `conf.get('Project')` with a `None` guard throughout.
+- **projects**: Fixed `TypeError` on file deletion — `_on_filename_deleted` was passing
+  the entire `filepaths` set to `os.path.basename()`; now iterates the set correctly.
+- **projects**: Fixed `description()` returning a raw `KeyError` object instead of a
+  string, and crashing with `TypeError` when the config value was `None`.
+- **projects**: Fixed `remove_batch()` calling `save()` N+1 times; now saves once after
+  all removals.
+- **util**: Fixed `NameError` — `GLib` was used in `check_remote_directory_sync()` but
+  never imported; changed to `except Exception`.
+- **util**: Fixed `get_files()` returning directories alongside files, causing `IndexError`
+  in every caller that accessed filename fields.
+- **util**: Fixed `filename_delete()` using `os.system("rm '...'")` — replaced with
+  `os.unlink()` to prevent shell injection and expose errors properly.
+- **util**: Fixed `zip_list()` leaking an open `ZipFile` handle; now uses a context manager.
+- **util**: Fixed `which()` always returning `None` (body was entirely commented out);
+  replaced with `shutil.which()`.
+- **util**: Fixed `since_date_last_six_months()` returning a `date` object while all
+  sibling methods return `datetime`, causing `TypeError` on comparisons.
+- **util**: Fixed `Field` dict missing `Concept` (index 5), causing `KeyError` on any
+  `field_used(Concept, …)` call.
+- **util**: Fixed `Gio.content_type_guess()` called with `f"filename={path}"` instead of
+  the bare path — MIME type detection was always wrong.
+- **util**: Fixed shell injection in `directory_open()` and `filename_display()` which used
+  `os.system("xdg-open '...'")`. Replaced with `subprocess.Popen`.
+- **stats**: Fixed crash on malformed filenames — `_build()` called `.year` on the result
+  of `string_to_datetime()` without checking for `None`; now skips bad entries.
+- **watcher**: Fixed second `MiAZWatcher` instance never monitoring anything — the
+  `GObject.__init__` was called twice and `set_path()` / `timeout_add_seconds()` were
+  only called when `sid == 0`. Replaced runtime signal registration with `__gsignals__`
+  and removed the guard so initialisation always runs.
+- **webserver**: Fixed `start()` calling itself recursively on port collision, which could
+  exhaust the call stack. Replaced with a `while` loop.
+- **webserver**: Fixed `os.chdir(self.directory)` changing the process-wide working
+  directory. Replaced with `functools.partial(SimpleHTTPRequestHandler, directory=…)`.
+- **config**: Fixed `load()` returning `[]` (a list) on JSON parse error; callers expect
+  a `dict`. Now returns `{}` and logs the exception.
+- **config**: Fixed dead unreachable branch in `get()` (`if key in config` inside
+  `except KeyError` is always `False`). Simplified to `return None`.
+- **config**: Fixed `add()` and `remove()` continuing execution past an empty-key warning,
+  allowing invalid keys to be written. Both now return `False` immediately.
+- **log**: Fixed `enable_file_output()` raising `AttributeError` when called before
+  `add_file_handler()`. Added class-level `file_handler = None` and an early-return guard.
+
+#### Frontend (widgets — fixed in earlier session)
+
+- **views**: Fixed signal handler accumulating on `CheckButton` every time a cell was
+  recycled on scroll. Signal now connected once in `setup`; `bind` uses `handler_block`.
+- **pluginuimanager**: Fixed `NameError` — `requests` and `HTTPError` were used without
+  import. Added guarded import with `_REQUESTS_AVAILABLE` flag.
+- **pluginuimanager**: Fixed call to undefined `self.update_user_plugins()`.
+- **configview**: Fixed `HTTPError` used without import in `download_plugins()`. Added
+  guarded import and early-return guard.
+- **configview**: Replaced runtime `GObject.signal_new()` pattern with `__gsignals__` in
+  `MiAZUserPlugins`.
+- **sidebar**: Fixed `get_service('repository')` typo — should be `get_service('repo')`,
+  which caused `AttributeError` on every `update_repo_status()` call.
+- **window**: Fixed `_on_window_close_request()` calling `window.close()`, which
+  re-emitted `close-request` and could loop. Changed to `return False`.
+- **mainwindow**: Fixed typo `'page-webbroser'` → `'page-webbrowser'`, causing
+  `_setup_webbrowser()` to be called and a new WebKit view to be created on every
+  `_setup_ui()` invocation.
+- **columnview**: Fixed `eval()` used for attribute access in sort comparators — replaced
+  with `getattr()`, eliminating arbitrary code execution risk and giving ~10× speedup.
+- **selector**: Fixed `searchentry.get_text()` called on every item in a filter pass;
+  text is now cached before `refilter()`.
+- **searchbar**: Fixed search entry registered under `'searchbar_entry'` while the rest
+  of the app uses `'searchentry'`.
+- **button**: Fixed `popover.present()` called during construction before the popover
+  had a parent window.
+- **columnview**: Fixed `get_selected()` iterating the raw store with `is_selected()`,
+  giving wrong results after filtering/sorting. Replaced with `get_selected_item()` (O(1)).
+
+### Performance
+
+- **repository**: `get()` no longer calls `setup()` (JSON I/O) on every property access.
+  Result is cached in `_conf_cache` and invalidated when `load()` is called.
+- **stats**: `get()` no longer triggers a full directory scan on every call. Stats are
+  built once and callers invoke `_build()` directly when a refresh is needed.
+- **util**: `field_used()` no longer performs a full O(N) scan per call. An inverted
+  field-index is built once per directory and invalidated automatically on file changes.
+- **workspace**: `update()` no longer called `get_files()` twice per refresh.
+- **workspace**: `_on_filter_selected()` no longer performed a full directory scan on
+  every keystroke and dropdown change.
+- **workspace**: Date range bounds are now parsed once per filter pass, not once per
+  document.
+- **workspace**: Dropdowns and search text are now resolved once per filter pass.
+- **workspace**: `initialize_caches()` no longer loaded the cache JSON from disk only
+  to immediately discard it.
+- **columnview**: `update()` now uses a single `splice()` call instead of `remove_all()`
+  + `splice()`, sending one model-change notification instead of two.
+
+### Changed
+
+- **util**: `filename_validate()` now delegates to `filename_is_normalized()` (they were
+  functional duplicates).
+- **util**: `valid_key()` now applies both substitutions in a single chained expression.
+- **util**: `get_files_recursively()` now uses `os.walk(topdown=True)` with in-place
+  directory pruning, replacing an O(N²) substring-based hidden-directory check.
+- **util**: `download_and_unzip()` now checks for the `requests` library at call time and
+  logs a clear error if it is not installed.
+- **watcher**: First `next_files_async` batch size changed from 10 to 100 to match all
+  subsequent batches.
+- **webserver**: Log message corrected from "Sleeping 5 seconds" to "Sleeping 3 seconds".
+- **config**: `set()` return-type annotation corrected from `-> None` to `-> bool`.
+- **config**: `save_available()`, `save_used()`, `save_data()`, and `MiAZConfigApp.save()`
+  mutable default argument `items: dict = {}` replaced with `items: dict = None`.
+- **repository**: `load()` `path` parameter made optional (`path=None`) since it was
+  never used internally.
+- **mainwindow**: Removed duplicate `add_widget('page-404', …)` call that overwrote the
+  content widget with the `GtkStackPage` wrapper.
+- **log**: `has_console_handler()` comment added explaining why strict type equality
+  (not `isinstance`) is used to exclude `FileHandler`.
+
+### Removed
+
+- **config**: Removed dead unreachable branch in `get()`.
+- **repository**: Removed commented-out `except KeyError` block in `validate()`.
+- **log**: Removed unused `counter = 0` class variable.
+- **widget**: Deleted `widget.py` — the file's own comment stated "Not used" and no
+  import of `MiAZWidget` was found anywhere in the codebase.
+- **settings**: Removed dead `_on_selected_repo()` method (defined but never connected
+  to any signal) and empty `on_filechooser_response_source()` stub.
+- **configview**: Removed 15 lines of dead code after an early `return` in
+  `_add_config_menubutton()`.
+- **columnview**: Removed dead `_on_filter_view()` methods from both `MiAZColumnView`
+  and `MiAZColumnViewSelector` (referenced non-existent attributes).
+
+### Fixed (signal / GObject patterns)
+
+- **util**, **watcher**: Replaced `GObject.signal_new()` in `__init__` with class-level
+  `__gsignals__` dict, eliminating duplicate-registration errors on second instantiation.
+- **config**, **repository**, **configview**: Same `__gsignals__` migration (done in
+  prior session).
+- **config**, **stats**, **repository**, **watcher**: Class-level mutable dicts (`cache`,
+  `stats`, `_errmsg`, `before`) moved to instance `__init__` to prevent cross-instance
+  data sharing.
+
+### Fixed (i18n)
+
+- **sidebar**: Fixed untranslatable f-string in `update_repo_status()`; now uses
+  `_('…').format(…)`.
+- **configview**: Fixed `_(f'<b>{key}</b>')` → `f'<b>{_(key)}</b>'` so the key string
+  is extracted correctly by xgettext.
+- **pages**: Fixed `_(f"Welcome to {shortname}!")` → `_("Welcome to {shortname}!").format(…)`.
+
+### Fixed (deprecated GTK API)
+
+- **mainwindow**, **assistant**, **statusbar**, **views**, **pages**, **button**:
+  Replaced all `get_style_context().add_class()` / `remove_class()` calls with
+  `add_css_class()` / `remove_css_class()` (deprecated since GTK 4.10).
+
+### Fixed (Python patterns)
+
+- **about**, **button**, **pages**, **assistant**: Fixed `super(ParentClass, self).__init__()`
+  → `super().__init__()` in five classes.
+- **data**: Added prominent TODO comment to unimplemented `MiAZData` / `MiAZDataBackup`
+  / `MiAZDataRestore` stubs.
+- **models**: Fixed `# File: watcher.py` in module docstring → `# File: models.py`.
+- **repository**: Fixed typo `"initialited"` → `"initialized"` in log message.
+- **webbrowser**: Same typo fix in log message; removed duplicate widget registration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,273 @@
+# CLAUDE.md — MiAZ Project
+
+> Personal Document Organizer  
+> Repo: https://github.com/t00m/MiAZ  
+> App ID: `io.github.t00m.MiAZ`  
+> License: GPL v3
+
+---
+
+## What MiAZ does
+
+MiAZ is a **GTK4/Libadwaita desktop application** that organises personal documents by enforcing a strict 7-field filename convention:
+
+```
+{date}-{country}-{group}-{sentby}-{purpose}-{concept}-{sentto}
+```
+
+Example: `20240315-ES-HOU-BANKNAME-INV-Q1invoice-JOHNDOE`
+
+The **directory is the database** — no SQLite, no external DB. Everything is derived from filenames.
+
+---
+
+## Tech stack
+
+| Layer | Technology | Min version |
+|---|---|---|
+| Language | Python | 3.9 |
+| GUI toolkit | GTK | 4.10 |
+| GNOME style | Libadwaita | 1.6 |
+| Python–GTK bindings | PyGObject / GObject | 3.50 |
+| Build system | Meson + Ninja | — |
+| Distribution | Flatpak (in progress) | — |
+| i18n | gettext via GLib | — |
+
+---
+
+## Repository layout
+
+```
+MiAZ/                            ← repo root
+├── MiAZ/                        ← Python package
+│   ├── __init__.py              ← version / pkgdatadir constants
+│   ├── main.py                  ← entry point (Adw.Application subclass)
+│   ├── app/                     ← top-level application shell
+│   ├── backend/                 ← business logic (NO GTK imports here)
+│   ├── frontend/                ← widgets, dialogs, pages (GTK/Adw)
+│   └── plugins/                 ← built-in and user plugins
+├── data/
+│   ├── icons/hicolor/           ← application icons
+│   ├── *.desktop.in             ← desktop entry
+│   ├── *.metainfo.xml.in        ← AppStream metadata
+│   └── *.gschema.xml            ← GSettings schema
+├── po/                          ← translations (POTFILES, *.po)
+├── build-aux/meson/             ← postinstall.py and meson helpers
+├── flatpak/                     ← Flatpak build helpers
+├── scripts/
+│   └── install/local/           ← install_user.sh / uninstall_user.sh
+├── meson.build                  ← root Meson file
+├── meson_options.txt
+├── pyproject.toml
+└── io.github.t00m.MiAZ.json    ← Flatpak manifest
+```
+
+---
+
+## Architecture rules
+
+### Backend (`MiAZ/backend/`)
+- **Zero GTK/Adw imports** — must be testable headlessly.
+- Owns: filename parsing/validation, repository management (CRUD on files), plugin loading, settings persistence via GSettings.
+- Exposes a clean API that the frontend calls.
+
+### Frontend (`MiAZ/frontend/`)
+- All GTK4 / Libadwaita widgets live here.
+- **Never perform file I/O directly** — always call backend APIs.
+- Use `GLib.idle_add()` to marshal background-thread results back to the UI.
+
+### Plugins (`MiAZ/plugins/`)
+- Each plugin is a subdirectory with a `plugin.py` implementing the `Plugin` contract (see below).
+- Plugins may add frontend panels **or** backend processors — not both in a single plugin.
+
+---
+
+## Filename convention (core domain)
+
+The 7 fields, in order:
+
+| # | Field | Format | Example |
+|---|---|---|---|
+| 1 | Date | `%Y%m%d` | `20240315` |
+| 2 | Country | ISO-3166 Alpha-2 | `ES` |
+| 3 | Group | 3-char code | `HOU`, `FIN`, `EDU` |
+| 4 | SentBy | Free (no hyphens) | `BANKNAME` |
+| 5 | Purpose | 3-char code | `INV`, `REQ`, `INF` |
+| 6 | Concept | Free text | `Q1invoice` |
+| 7 | SentTo | Free (no hyphens) | `JOHNDOE` |
+
+Separator: `-` (hyphen). Any file added to a repository directory is **automatically renamed** to comply.
+
+When writing code that parses or constructs filenames, always validate all 7 fields and reject/flag non-compliant names rather than silently ignoring them.
+
+---
+
+## Build & install
+
+```bash
+# Developer local install (user scope, no root)
+./scripts/install/local/install_user.sh
+
+# Manual Meson workflow
+meson setup _build --prefix="$HOME/.local"
+ninja -C _build
+ninja -C _build install
+
+# Uninstall
+./scripts/uninstall/uninstall_user.sh
+
+# Flatpak (when available)
+flatpak-builder --user --install --force-clean _flatpak_build io.github.t00m.MiAZ.json
+flatpak run io.github.t00m.MiAZ
+```
+
+Prerequisites: `meson`, `ninja`, `python3 >= 3.9`, `PyGObject >= 3.50`, `GTK >= 4.10`, `Libadwaita >= 1.6`.
+
+---
+
+## GObject / GTK4 conventions used in this project
+
+```python
+import gi
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+from gi.repository import Gtk, Adw, Gio, GLib, GObject
+```
+
+**Always call `gi.require_version()` before any `from gi.repository` import.**
+
+### Signal connections
+```python
+widget.connect('signal-name', self._handler)
+# For background → UI updates:
+GLib.idle_add(self._update_ui, result)
+```
+
+### List model (GTK4 MVC — no GtkListStore/GtkTreeView)
+```python
+store = Gio.ListStore(item_type=MyGObjectItem)
+filter_model = Gtk.FilterListModel(model=store)
+sel_model = Gtk.SingleSelection(model=filter_model)
+column_view = Gtk.ColumnView(model=sel_model)
+```
+
+### Window structure
+```python
+class MiAZWindow(Adw.ApplicationWindow):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(Adw.HeaderBar())
+        toolbar_view.set_content(self._build_content())
+        self.set_content(toolbar_view)
+```
+
+---
+
+## Plugin contract
+
+```python
+# plugins/myplugin/plugin.py
+class Plugin:
+    name = 'myplugin'           # unique slug
+    title = 'My Plugin'         # human-readable
+    description = 'One line.'
+
+    def activate(self, app):
+        """Called when plugin is enabled. Receive the Adw.Application."""
+
+    def deactivate(self):
+        """Called when plugin is disabled or app quits."""
+```
+
+---
+
+## Coding standards
+
+- Python 3.9+ compatible syntax (no 3.10+ union types with `|` in annotations).
+- PEP 8 naming: `snake_case` for methods and variables, `PascalCase` for classes.
+- Private methods prefixed with `_` (e.g., `_on_button_clicked`).
+- Signal handler naming: `_on_<widget>_<signal>` (e.g., `_on_search_entry_changed`).
+- No bare `except:` — always catch specific exceptions or at minimum `Exception as e`.
+- Backend code must have no side-effects on import.
+- Do **not** use `print()` for debug output — use Python `logging` module:
+  ```python
+  import logging
+  log = logging.getLogger(__name__)
+  log.debug("Processing file: %s", path)
+  ```
+
+---
+
+## i18n
+
+Translatable strings use `_()`:
+```python
+from gi.repository import GLib
+_ = GLib.dgettext.bind('miaz')   # or via standard gettext
+label = Gtk.Label(label=_("Document Organizer"))
+```
+
+Translation files live in `po/`. Update with:
+```bash
+ninja -C _build miaz-update-po
+```
+
+---
+
+## GSettings schema
+
+Schema ID: `io.github.t00m.MiAZ`  
+Schema file: `data/io.github.t00m.MiAZ.gschema.xml`
+
+```python
+settings = Gio.Settings(schema_id='io.github.t00m.MiAZ')
+# Bind widget property to setting:
+settings.bind('some-key', widget, 'property', Gio.SettingsBindFlags.DEFAULT)
+```
+
+---
+
+## Common tasks
+
+### Add a new Libadwaita dialog
+1. Create `MiAZ/frontend/dialogs/my_dialog.py` with a class extending `Adw.Dialog` or `Adw.AlertDialog`.
+2. Import and instantiate from the relevant view; call `.present(parent)`.
+
+### Add a new backend service
+1. Create `MiAZ/backend/my_service.py` — no GTK imports.
+2. Wire it into the application object in `main.py` or `app/__init__.py`.
+
+### Add a new plugin
+1. Create `MiAZ/plugins/myplugin/` with `plugin.py` implementing the `Plugin` contract.
+2. Register in the plugin manager (see `backend/plugin_manager.py`).
+
+### Add a translated string
+1. Wrap with `_("...")`.
+2. Run `ninja -C _build miaz-update-po` to regenerate `po/miaz.pot`.
+
+### Run without installing
+```bash
+PYTHONPATH=. python -m MiAZ.main
+```
+
+---
+
+## What to avoid
+
+- Do **not** import GTK inside `backend/`.
+- Do **not** block the GTK main loop — use threads + `GLib.idle_add()`.
+- Do **not** use deprecated GTK3 widgets (`GtkListStore`, `GtkTreeView`, `GtkDialog` subclassing).
+- Do **not** hardcode paths — use `pkgdatadir` from `MiAZ/__init__.py`.
+- Do **not** rename files outside of the MiAZ rename pipeline — always go through the backend.
+- Do **not** store application state in global module-level variables.
+
+---
+
+## Useful references
+
+- [GNOME Developer Docs](https://developer.gnome.org/)
+- [PyGObject API Reference](https://pygobject.gnome.org/reference/)
+- [Libadwaita Widget Gallery](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/widget-gallery.html)
+- [GNOME HIG](https://developer.gnome.org/hig/)
+- [Flatpak docs](https://docs.flatpak.org/)

--- a/data/resources/plugins/MiAZAddFromDir/adddir.py
+++ b/data/resources/plugins/MiAZAddFromDir/adddir.py
@@ -63,7 +63,7 @@ class MiAZAddDirectoryPlugin(GObject.GObject, Peas.Activatable):
 
 
     def do_deactivate(self):
-        self.log.debug("Plugin deactivation not implemented")
+        self.plugin.set_started(False)
 
     def startup(self, *args):
         if not self.plugin.started():
@@ -83,10 +83,10 @@ class MiAZAddDirectoryPlugin(GObject.GObject, Peas.Activatable):
     def _on_filechooser_response(self, dialog, result):
         try:
             folder = dialog.select_folder_finish(result)
-            filepaths = glob.glob(os.path.join(folder, '*'))
+            dirpath = folder.get_path()
+            filepaths = glob.glob(os.path.join(dirpath, '*'))
             self.app.set_status(MiAZStatus.BUSY)
-
-            threading.Thread(target=self.import_directory(filepaths), daemon=True).start()
+            threading.Thread(target=self.import_directory, args=(filepaths,), daemon=True).start()
         except GLib.Error as err:
             self.srvdlg.show_error(title='Error selecting files', body=err.message)
             self.log.error(f"{err.domain} > {err.message}")
@@ -95,25 +95,23 @@ class MiAZAddDirectoryPlugin(GObject.GObject, Peas.Activatable):
         total_files = len(filepaths)
         watcher = self.app.get_service('watcher')
         watcher.set_active(False)
+        try:
+            for i, filepath in enumerate(filepaths):
+                if hasattr(self, 'cancelled') and self.cancelled:
+                    break
 
-        for i, filepath in enumerate(filepaths):
-            if hasattr(self, 'cancelled') and self.cancelled:
-                break
+                progress = (i + 1) / total_files
+                self.log.debug(f"Importing file from {filepath}")
+                GLib.idle_add(self.update_progress, progress, f"Importing file {i+1}/{total_files}")
 
-            # Update progress
-            progress = (i + 1) / total_files
-            self.log.debug(f"Importing file from {filepath}")
-            GLib.idle_add(self.update_progress, progress, f"Importing file file {i+1}/{total_files}")
-
-            # Import file
-            btarget = self.util.filename_normalize(filepath)
-            target = os.path.join(self.repository.docs, btarget)
-            GLib.idle_add(self.util.filename_import,filepath, target)
+                btarget = self.util.filename_normalize(filepath)
+                target = os.path.join(self.repository.docs, btarget)
+                self.util.filename_import(filepath, target)
+        finally:
+            GLib.idle_add(watcher.set_active, True)
+            GLib.idle_add(self.app.set_status, MiAZStatus.RUNNING)
 
     def update_progress(self, fraction, text):
         self.log.info(f"{fraction} {text}")
         if fraction >= 1.0:
-            watcher = self.app.get_service('watcher')
-            watcher.set_active(True)
-            self.app.set_status(MiAZStatus.RUNNING)
             self.srvdlg.show_info(title='Import directory', body=_('All documents imported successfully'))

--- a/data/resources/plugins/MiAZDeleteDoc/delete.py
+++ b/data/resources/plugins/MiAZDeleteDoc/delete.py
@@ -64,7 +64,7 @@ class MiAZDeleteItemPlugin(GObject.GObject, Peas.Activatable):
         self.workspace.connect('workspace-loaded', self.startup)
 
     def do_deactivate(self):
-        self.log.debug("Plugin deactivation not implemented")
+        self.plugin.set_started(False)
 
     def startup(self, *args):
         if not self.plugin.started():

--- a/data/resources/plugins/MiAZImportDoc/adddoc.py
+++ b/data/resources/plugins/MiAZImportDoc/adddoc.py
@@ -2,7 +2,7 @@
 # pylint: disable=E1101
 
 """
-# File: export2csv.py
+# File: adddoc.py
 # Author: Tomás Vírseda
 # License: GPL v3
 # Description: Plugin for importing documents from filesystem
@@ -60,7 +60,7 @@ class MiAZAddDocumentPlugin(GObject.GObject, Peas.Activatable):
         workspace.connect('workspace-loaded', self.startup)
 
     def do_deactivate(self):
-        self.log.debug("Plugin deactivation not implemented")
+        self.plugin.set_started(False)
 
     def startup(self, *args):
         if not self.plugin.started():
@@ -88,8 +88,11 @@ class MiAZAddDocumentPlugin(GObject.GObject, Peas.Activatable):
                     target = os.path.join(self.repository.docs, btarget)
                     self.util.filename_import(source, target)
                 parent = self.app.get_widget('window')
-                self.srvdlg.show_info(title='Import documents', body=f'{len(filepaths)} documents imported successfully', parent=parent)
+                self.srvdlg.show_info(
+                    title=_('Import documents'),
+                    body=_('{count} documents imported successfully').format(count=len(filepaths)),
+                    parent=parent)
         except Exception as error:
-            self.srvdlg.show_error(title='Error selecting files', body=error)
+            self.srvdlg.show_error(title='Error selecting files', body=str(error))
             self.log.error(f"Error selecting files: {error}")
 

--- a/data/resources/plugins/MiAZMassRename/massrename.py
+++ b/data/resources/plugins/MiAZMassRename/massrename.py
@@ -2,7 +2,7 @@
 # pylint: disable=E1101, R0914
 
 """
-# File: export2csv.py
+# File: massrename.py
 # Author: Tomás Vírseda
 # License: GPL v3
 # Description: Plugin for exporting items to CSV
@@ -20,7 +20,7 @@ from gi.repository import Peas
 
 from MiAZ.backend.status import MiAZStatus
 from MiAZ.frontend.desktop.services.pluginsystem import MiAZPlugin
-from MiAZ.backend.models import File, Group, Country, Purpose, SentBy, SentTo, Date
+from MiAZ.backend.models import File, Group, Country, Purpose, SentBy, SentTo, Date, Concept
 from MiAZ.frontend.desktop.widgets.configview import MiAZCountries
 from MiAZ.frontend.desktop.widgets.configview import MiAZGroups
 from MiAZ.frontend.desktop.widgets.configview import MiAZPurposes
@@ -48,6 +48,7 @@ Field[Country] = 1
 Field[Group] = 2
 Field[SentBy] = 3
 Field[Purpose] = 4
+Field[Concept] = 5
 Field[SentTo] = 6
 
 Configview = {}
@@ -90,7 +91,7 @@ class MiAZMassRenamingPlugin(GObject.GObject, Peas.Activatable):
         self.workspace.connect('workspace-loaded', self.startup)
 
     def do_deactivate(self):
-        self.log.debug("Plugin deactivation not implemented")
+        self.plugin.set_started(False)
 
     def startup(self, *args):
         if not self.plugin.started():
@@ -132,21 +133,19 @@ class MiAZMassRenamingPlugin(GObject.GObject, Peas.Activatable):
             self.util = self.app.get_service('util')
             citems = []
             for item in items:
-                try:
-                    source = item.id
-                    name, ext = self.util.filename_details(source)
-                    n = Field[item_type]
-                    tmpfile = name.split('-')
-                    tmpfile[n] = dropdown.get_selected_item().id
-                    filename = f"{'-'.join(tmpfile)}.{ext}"
-                    target = os.path.join(os.path.dirname(source), filename)
-                    txtId = os.path.basename(source)
-                    txtTitle = os.path.basename(target)
-                    citems.append(File(id=txtId, title=txtTitle))
-                except AttributeError as error:
-                    # FIXME: AtributeError: 'NoneType' object has no attribute 'id'
-                    # It happens when managing resources from inside the dialog
-                    self.log.error(error)
+                selected = dropdown.get_selected_item()
+                if selected is None:
+                    continue
+                source = item.id
+                name, ext = self.util.filename_details(source)
+                n = Field[item_type]
+                tmpfile = name.split('-')
+                tmpfile[n] = selected.id
+                filename = f"{'-'.join(tmpfile)}.{ext}"
+                target = os.path.join(os.path.dirname(source), filename)
+                txtId = os.path.basename(source)
+                txtTitle = os.path.basename(target)
+                citems.append(File(id=txtId, title=txtTitle))
             columnview.update(citems)
 
         def calendar_day_selected(calendar, label, columnview, items):
@@ -212,7 +211,9 @@ class MiAZMassRenamingPlugin(GObject.GObject, Peas.Activatable):
             i_title = item_type.__title__
             i_title_plural = item_type.__title_plural__
             box = self.factory.create_box_vertical(spacing=6, vexpand=True, hexpand=True)
-            label = self.factory.create_label(_(f'Rename {len(items)} files by setting the field <b>{i_title}</b> to:\n'))
+            label = self.factory.create_label(
+                _('Rename {count} files by setting the field <b>{field}</b> to:\n')
+                .format(count=len(items), field=i_title))
             dropdown = self.factory.create_dropdown_generic(item_type)
             icon_name = f'io.github.t00m.MiAZ-res-{i_title_plural.lower()}'
             self.log.debug(icon_name)
@@ -246,7 +247,6 @@ class MiAZMassRenamingPlugin(GObject.GObject, Peas.Activatable):
             hbox.append(label)
             frame = Gtk.Frame()
             cv = MiAZColumnViewMassRename(self.app)
-            # ~ cv.get_style_context().add_class(class_name='caption')
             cv.set_hexpand(True)
             cv.set_vexpand(True)
             frame.set_child(cv)

--- a/data/resources/plugins/MiAZRenameDoc/renameitem.py
+++ b/data/resources/plugins/MiAZRenameDoc/renameitem.py
@@ -60,12 +60,9 @@ class MiAZToolbarRenameItemPlugin(GObject.GObject, Peas.Activatable):
         # Connect signals to startup
         self.workspace.connect('workspace-loaded', self.startup)
         self.workspace.connect('workspace-view-updated', self._on_selection_changed)
-        view = self.app.get_widget('workspace-view')
-        selection = view.get_selection()
-        selection.connect('selection-changed', self._on_selection_changed)
 
     def do_deactivate(self):
-        self.log.debug("Plugin deactivation not implemented")
+        self.plugin.set_started(False)
 
     def _on_selection_changed(self, *args):
         items = self.workspace.get_selected_items()
@@ -83,6 +80,10 @@ class MiAZToolbarRenameItemPlugin(GObject.GObject, Peas.Activatable):
             # Add plugin to its default (sub)category
             self.plugin.install_menu_entry(menuitem)
 
+            # Connect selection signal now that workspace is loaded
+            view = self.app.get_widget('workspace-view')
+            if view is not None:
+                view.get_selection().connect('selection-changed', self._on_selection_changed)
 
             # Button
             if self.app.get_widget('toolbar-top-button-rename') is None:
@@ -107,8 +108,7 @@ class MiAZToolbarRenameItemPlugin(GObject.GObject, Peas.Activatable):
         rename_widget.set_data(doc)
         window = self.app.get_widget('window')
         title = _('Rename document')
-        body = '' # _(f'<big>{i_title} {selected_item.id} is still being used</big>')
-        dialog = self.srvdlg.show_question(title=title, body=body, widget=rename_widget,width=1024)
+        dialog = self.srvdlg.show_question(title=title, body='', widget=rename_widget, width=1024)
         dialog.add_response("preview", _("Preview"))
         dialog.set_response_enabled("preview", True)
         self.app.add_widget('dialog-rename', dialog)

--- a/data/resources/plugins/MiAZViewDoc/viewitem.py
+++ b/data/resources/plugins/MiAZViewDoc/viewitem.py
@@ -2,7 +2,7 @@
 # pylint: disable=E1101
 
 """
-# File: export2csv.py
+# File: viewitem.py
 # Author: Tomás Vírseda
 # License: GPL v3
 # Description: Plugin for exporting items to CSV
@@ -56,13 +56,9 @@ class MiAZToolbarViewItemPlugin(GObject.GObject, Peas.Activatable):
         self.workspace = self.app.get_widget('workspace')
         self.workspace.connect('workspace-loaded', self.startup)
         self.workspace.connect('workspace-view-updated', self._on_selection_changed)
-        view = self.app.get_widget('workspace-view')
-        view.cv.connect("activate", self.document_display)
-        selection = view.get_selection()
-        selection.connect('selection-changed', self._on_selection_changed)
 
     def do_deactivate(self):
-        self.log.debug("Plugin deactivation not implemented")
+        self.plugin.set_started(False)
 
     def _on_selection_changed(self, *args):
         items = self.workspace.get_selected_items()
@@ -79,6 +75,13 @@ class MiAZToolbarViewItemPlugin(GObject.GObject, Peas.Activatable):
 
             # Add plugin to its default (sub)category
             self.plugin.install_menu_entry(menuitem)
+
+            # Connect view signals now that workspace is loaded
+            view = self.app.get_widget('workspace-view')
+            if view is not None:
+                if hasattr(view, 'cv'):
+                    view.cv.connect("activate", self.document_display)
+                view.get_selection().connect('selection-changed', self._on_selection_changed)
 
             # Button
             if self.app.get_widget('toolbar-top-button-view') is None:

--- a/data/resources/plugins/MiAZWorkspaceToggleView/wstoggleview.py
+++ b/data/resources/plugins/MiAZWorkspaceToggleView/wstoggleview.py
@@ -2,11 +2,13 @@
 # pylint: disable=E1101
 
 """
-# File: hello.py
+# File: wstoggleview.py
 # Author: Tomás Vírseda
 # License: GPL v3
 # Description: Scan plugin
 """
+
+from gettext import gettext as _
 
 from gi.repository import Adw
 from gi.repository import Gdk
@@ -55,10 +57,8 @@ class MiAZWorkspaceToggleViewPlugin(GObject.GObject, Peas.Activatable):
         self.workspace.connect('workspace-loaded', self.startup)
 
     def do_deactivate(self):
-        self.log.error("Plugin deactivated")
-
-    def check_plugin(self, *args):
-        self.log.info(f"Plugin loaded? {self.plugin_info.is_loaded()}")
+        self.log.debug("Plugin deactivated")
+        self.plugin.set_started(False)
 
     def startup(self, *args):
         if not self.plugin.started():
@@ -140,7 +140,7 @@ class MiAZWorkspaceToggleViewPlugin(GObject.GObject, Peas.Activatable):
         config = self.plugin.get_config_data()
         try:
             visible = config['icon_visible']
-        except:
+        except KeyError:
             visible = config['icon_visible'] = True
             self.plugin.set_config_data(config)
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('MiAZ',
-         version : '0.1.19+build.8',
+         version : '0.1.20+build.1',
     meson_version: '>= 1.5.1',
   default_options: [ 'warning_level=2',
                    ],


### PR DESCRIPTION
### Fixed

#### Plugins

- **adddir**: Fixed `threading.Thread(target=self.import_directory(filepaths))` — function
  was called immediately and its return value (`None`) passed as target; import ran on
  the main GTK thread and the spawned thread was a no-op. Fixed to pass `target` and
  `args` separately.
- **adddir**: Fixed `TypeError` — `dialog.select_folder_finish()` returns `Gio.File`, not
  a path string; `os.path.join(Gio.File, '*')` crashed immediately. Added `folder.get_path()`.
- **adddir**: Fixed file I/O (`filename_import`) scheduled via `GLib.idle_add` from the
  background thread, which queued it back onto the main GTK thread. I/O now runs directly
  in the thread; only the progress callback uses `idle_add`.
- **adddir**: Fixed watcher staying permanently disabled when an import was cancelled or
  raised — `watcher.set_active(False)` had no corresponding re-activation on error paths.
  Added `try/finally` to guarantee restoration.
- **adddoc**: Fixed `show_error(body=error)` passing an `Exception` object to the dialog
  instead of a string. Changed to `body=str(error)`.
- **adddoc**: Fixed untranslatable `title='Import documents'` and `body=f'...'` strings;
  both are now wrapped with `_()` using `.format()` for the dynamic value.
- **massrename**: Fixed `dropdown.get_selected_item()` returning `None` when no item is
  selected; `.id` access raised `AttributeError`, silently swallowed by a FIXME catch-all.
  Added explicit `None` guard with `continue`.
- **massrename**: Fixed `_(f'Rename {len(items)} ... <b>{i_title}</b> ...')` — an f-string
  inside `_()` is invisible to xgettext. Changed to `_('...{count}...{field}...').format(...)`.
- **renameitem**: Fixed `view.get_selection()` called in `do_activate()` before
  `'workspace-loaded'` fires — if the workspace view is not yet registered, `view` is
  `None` and the plugin fails to load. Moved the `selection.connect()` call into
  `startup()` with a `None` guard.
- **viewitem**: Fixed `view.cv.connect("activate", ...)` and `view.get_selection().connect()`
  called in `do_activate()` before the workspace was loaded. Moved both into `startup()`
  with `None` and `hasattr` guards.
- **wstoggleview**: Fixed `NameError` at module load — `_()` was used in the `plugin_info`
  dict before `_` was imported. Added `from gettext import gettext as _`.
- **wstoggleview**: Fixed bare `except:` in `show_settings()` catching `SystemExit` and
  `KeyboardInterrupt`. Changed to `except KeyError:`.
- **wstoggleview**: Removed dead `check_plugin()` method that referenced `self.plugin_info`
  (never assigned) — would `AttributeError` if called.
- **wstoggleview**: Fixed `do_deactivate()` logging at `error` level for normal deactivation.
  Changed to `self.log.debug(...)`.
- **All 7 plugins**: Fixed `do_deactivate()` not implemented — disabling a plugin left
  orphaned UI elements and duplicate signal handlers on re-enable; `plugin.started()` was
  still `True` so re-activation did nothing. All plugins now call
  `self.plugin.set_started(False)` in `do_deactivate()`.

#### Low quality (plugins)

- **adddir**: Fixed typo "Importing file file {i+1}/..." — "file" was doubled.
- **massrename**: Added `Field[Concept] = 5` — the local `Field` dict was missing index 5,
  inconsistent with the 7-field model and a latent `KeyError`.
- **massrename**: Removed commented-out deprecated `get_style_context().add_class()` call.
- **renameitem**: Removed dead comment referencing undefined `selected_item` and `i_title`.
- **adddoc, massrename, viewitem**: Fixed `# File: export2csv.py` copy-paste artefact in
  module docstrings.
- **wstoggleview**: Fixed `# File: hello.py` copy-paste artefact in module docstring.
